### PR TITLE
Allows adequate time for boot up on T2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,11 @@ var ACK_CMD = 0x00;
 var FIRMWARE_CMD = 0x01;
 var CRC_CMD = 0x07;
 var MODULE_ID_CMD = 0x08;
+/*
+ATTINY needs this long reboot & set up
+SPI controller (determined experimentally)
+*/
+var REBOOT_TIME = 150;
 
 
 function Attiny(hardware) {
@@ -24,7 +29,7 @@ function Attiny(hardware) {
   this.chipSelect = hardware.digital[0];
   this.reset = hardware.digital[1];
   this.irq = hardware.digital[2].rawWrite(false);
-  this.spi = hardware.SPI({clockSpeed : 1000, mode:2, chipSelect:this.chipSelect, chipSelectDelayUs:500});
+  this.spi = hardware.SPI({clockSpeed : 1000, dataMode:2, chipSelect:this.chipSelect, chipSelectDelayUs:500});
   this.transmitting = false;
   this.listening = false;
   this.chipSelect.output(true);
@@ -123,8 +128,8 @@ Attiny.prototype._checkModuleInformation = function(firmwareOptions, readFirmwar
 Attiny.prototype._reset = function(callback) {
   this.reset.low();
   this.reset.high();
-  // for Tessel 2, need to wait .1 seconds so that the attiny will reboot before acking
-  setTimeout(callback, 100);
+  // Time needed for attiny to reboot
+  setTimeout(callback, REBOOT_TIME);
 }
 
 Attiny.prototype._establishCommunication = function (callback) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attiny-common",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A common library for Tessel's ATTiny based modules",
   "main": "./lib/index.js",
   "scripts": {
@@ -16,7 +16,7 @@
     "spi"
   ],
   "dependencies" : {
-    "avr-isp": "0.0.4",
+    "avr-isp": "0.0.5",
     "sync-queue" : "~0.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Should be merged after https://github.com/tessel/avr-isp/pull/9 is deployed to npm.

Needs to be tested on T1.