### PR TITLE
increase bootup time for slow ir module

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ var MODULE_ID_CMD = 0x08;
 ATTINY needs this long reboot & set up
 SPI controller (determined experimentally)
 */
-var REBOOT_TIME = 150;
+var REBOOT_TIME = 200;
 
 
 function Attiny(hardware) {


### PR DESCRIPTION
Apparently, the IR modules takes longer to bootup and setup the SPI controller so this PR increases the amount of time to wait after a reset before checking firmware version and module id.

Fixes https://github.com/tessel/ir-attx4/issues/31