### PR TITLE
Fixes tessel/ambient-attx4#70

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ var MODULE_ID_CMD = 0x08;
 ATTINY needs this long reboot & set up
 SPI controller (determined experimentally)
 */
-var REBOOT_TIME = 150;
+var REBOOT_TIME = 50;
 
 /*
 The ADC will need 50 ADC clock cycles
@@ -140,9 +140,11 @@ Attiny.prototype._checkModuleInformation = function(firmwareOptions, readFirmwar
 
 Attiny.prototype._reset = function(callback) {
   this.reset.low();
-  this.reset.high();
-  // Time needed for attiny to reboot
-  setTimeout(callback, REBOOT_TIME);
+  this.reset.high(function() {
+    // Time needed for attiny to reboot
+    setTimeout(callback, REBOOT_TIME)
+  });
+
 }
 
 Attiny.prototype._establishCommunication = function (callback) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attiny-common",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "A common library for Tessel's ATTiny based modules",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
The Attiny needs some time after it reboots for the microcontroller to have fully booted and configured its peripherals. Previously, this was reboot time was being measured incorrectly because it was starting the timeout from after when GPIO toggling messages were queued with the domain socket rather than when we got a confirmed response. As a result, the `150` ms timeout was completing only about 70ms after the reset line was pulled low. This PR makes the rebooting time more accurate to what's going on with the hardware. 