### PR TITLE
Allows clients to decide on how much reboot time is necessary

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,11 +18,6 @@ var ACK_CMD = 0x00;
 var FIRMWARE_CMD = 0x01;
 var CRC_CMD = 0x07;
 var MODULE_ID_CMD = 0x08;
-/*
-ATTINY needs this long reboot & set up
-SPI controller (determined experimentally)
-*/
-var REBOOT_TIME = 50;
 
 /*
 The ADC will need 50 ADC clock cycles
@@ -52,7 +47,7 @@ function Attiny(hardware) {
 util.inherits(Attiny, events.EventEmitter);
 
 // In charge of initializing the modules
-Attiny.prototype.initialize = function(firmwareOptions, callback) {
+Attiny.prototype.initialize = function(rebootTime, firmwareOptions, callback) {
 
   var self = this;
 
@@ -69,7 +64,7 @@ Attiny.prototype.initialize = function(firmwareOptions, callback) {
   }
 
   // Reset the chip
-  self._reset(function() {
+  self._reset(rebootTime, function() {
 
     // Make sure we can communicate with the module
     self._establishCommunication(function (err, readFirmwareVersion, readModuleID) {
@@ -138,11 +133,11 @@ Attiny.prototype._checkModuleInformation = function(firmwareOptions, readFirmwar
   }
 }
 
-Attiny.prototype._reset = function(callback) {
+Attiny.prototype._reset = function(rebootTime, callback) {
   this.reset.low();
   this.reset.high(function() {
     // Time needed for attiny to reboot
-    setTimeout(callback, REBOOT_TIME)
+    setTimeout(callback, rebootTime)
   });
 
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attiny-common",
-  "version": "0.0.11",
+  "version": "0.1.0",
   "description": "A common library for Tessel's ATTiny based modules",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
Ambient and IR need different durations of time to reboot and configure their registers. I'd rather let clients choose how long to wait for boot up rather than always wait a maximum time.